### PR TITLE
PD-19: Created StateManager with tests

### DIFF
--- a/Assets/_PlatformerDevelopment/Scripts/Managers.meta
+++ b/Assets/_PlatformerDevelopment/Scripts/Managers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c60ac5b55b1294e67ae681b7ce053548
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_PlatformerDevelopment/Scripts/Managers/StateManager.cs
+++ b/Assets/_PlatformerDevelopment/Scripts/Managers/StateManager.cs
@@ -1,0 +1,50 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="StateManager.cs" company="PERIGON GAMES">
+//     Copyright (c) PERIGON GAMES. 2020 All Rights Reserved
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace PersonalDevelopment
+{
+    public enum State
+    {
+        StartMenu,
+        CharacterSelection,
+        PreGame,
+        Play,
+        EndGame
+    }
+
+    public interface IStateManager
+    {
+        event Action<State> OnStateChanged;
+        State GetState();
+
+        void SetState(State state);
+    }
+    
+    public class StateManager: IStateManager
+    {
+        private static State _gameState = State.StartMenu;
+        
+        public event Action<State> OnStateChanged;
+
+        /// <summary>
+        /// Sets the state of the application
+        /// </summary>
+        /// <returns></returns>
+        public State GetState()
+        {
+            return _gameState;
+        }
+
+        public void SetState(State state)
+        {
+            _gameState = state;
+            OnStateChanged?.Invoke(state);
+        }
+    }
+}
+

--- a/Assets/_PlatformerDevelopment/Scripts/Managers/StateManager.cs.meta
+++ b/Assets/_PlatformerDevelopment/Scripts/Managers/StateManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80c4a9d8b62c34b75b22334b170e9dee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_PlatformerDevelopment/Tests/StateManagerTests.cs
+++ b/Assets/_PlatformerDevelopment/Tests/StateManagerTests.cs
@@ -1,0 +1,82 @@
+﻿using NUnit.Framework;
+using PersonalDevelopment;
+
+namespace Tests
+{
+    public class StateManagerTests
+    {
+        // A Test behaves as an ordinary method
+        [Test]
+        public void TestStateManagerChangeStateToPlay()
+        {
+            // Arrange
+            var stateManager = new StateManager();
+            
+            //Act
+            stateManager.SetState(State.Play);
+            var result = stateManager.GetState();
+            
+            //Assert
+            Assert.AreEqual(result, State.Play, "State should be play");
+        }
+        
+        // A Test behaves as an ordinary method
+        [Test]
+        public void TestStateManagerStateTheSameWithDifferentObjects()
+        {
+            // Arrange
+            var stateManager_1 = new StateManager();
+            var stateManager_2 = new StateManager();
+            
+            //Act
+            stateManager_2.SetState(State.PreGame);
+            stateManager_1.SetState(State.Play);
+            var result = stateManager_2.GetState();
+            
+            //Assert
+            Assert.AreEqual(result, State.Play, "State should be play");
+        }
+
+        [Test]
+        public void TestStateManagerCallsBackOnStateChange()
+        {
+            //Arrange
+            var result = 0;
+            void OnStateChanged(State state)
+            {
+                result++;
+            }
+
+            var stateManager = new StateManager();
+            stateManager.OnStateChanged += OnStateChanged;
+
+            //Act
+            stateManager.SetState(State.Play);
+
+            //Assert
+            Assert.AreEqual(result, 1, "Result should be 1, since callback adds 1");
+        }
+        
+        [Test]
+        public void TestStateManagerCallsBackReturnsCorrectState()
+        {
+            //Arrange
+            var resultingState = State.StartMenu;
+            void OnStateChanged(State state)
+            {
+                resultingState = state;
+            }
+
+            var stateManager = new StateManager();
+            stateManager.OnStateChanged += OnStateChanged;
+
+            //Act
+            stateManager.SetState(State.Play);
+
+            //Assert
+            Assert.AreEqual(resultingState, State.Play, "Resulting state should be Play");
+        }
+
+        
+    }
+}

--- a/Assets/_PlatformerDevelopment/Tests/StateManagerTests.cs.meta
+++ b/Assets/_PlatformerDevelopment/Tests/StateManagerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0338751acdb3d4f1b9171e85c74fa651
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
StateManager is not a monobehaviour. 
I'm thinking it'll just be needed by calling
StateManager.SetState()
StateManager.GetState()

And that's it, no need for it to be on the scene.