### PR TITLE
PD-50: Player Input Bindings

### DIFF
--- a/Assets/_PlatformerDevelopment/Prefabs/Player.prefab
+++ b/Assets/_PlatformerDevelopment/Prefabs/Player.prefab
@@ -161,7 +161,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Actions: {fileID: -944628639613478452, guid: 463355acf59994997b671fc0c501b90c,
     type: 3}
-  m_NotificationBehavior: 3
+  m_NotificationBehavior: 2
   m_UIInputModule: {fileID: 0}
   m_DeviceLostEvent:
     m_PersistentCalls:
@@ -172,7 +172,87 @@ MonoBehaviour:
   m_ControlsChangedEvent:
     m_PersistentCalls:
       m_Calls: []
-  m_ActionEvents: []
+  m_ActionEvents:
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1410163244}
+        m_TargetAssemblyTypeName: PersonalDevelopment.PlayerMovementBehaviour, Scripts
+        m_MethodName: OnMove
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 1
+    m_ActionId: d53e6b7e-1d53-45b0-ac98-d6866d029aa7
+    m_ActionName: Player/Move[/Keyboard/a,/Keyboard/d,/Keyboard/leftArrow,/Keyboard/rightArrow]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 919a78a0-66c6-47b5-b71c-069cff3d1c69
+    m_ActionName: Player/Fire[/Mouse/rightButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: c64e88d6-aaf1-47a1-bf96-6290658f319c
+    m_ActionName: Player/Melee[/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4795651832562201028}
+        m_TargetAssemblyTypeName: PersonalDevelopment.PlayerJumpBehaviour, Scripts
+        m_MethodName: OnJumpPressed
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 2fbd39ee-c074-4053-9ec5-990ce11d58bb
+    m_ActionName: Player/Jump[/Keyboard/w,/Keyboard/upArrow]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: c5ce30b3-3e41-4fc7-bd35-956fc04dd7c9
+    m_ActionName: UI/Navigate[/Keyboard/w,/Keyboard/upArrow,/Keyboard/s,/Keyboard/downArrow,/Keyboard/a,/Keyboard/leftArrow,/Keyboard/d,/Keyboard/rightArrow]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 1481a553-d72e-4571-b080-662046c895ef
+    m_ActionName: UI/Submit[/Keyboard/enter]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: b38a8b2a-9ba3-4127-9fd4-fdb24b458fac
+    m_ActionName: UI/Cancel[/Keyboard/escape]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 9edbdd38-8739-459d-ac9f-4533be5fa3bf
+    m_ActionName: UI/Point[/Mouse/position,/Pen/position]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: c33a6f84-51ac-4dec-9144-eb0b1b1fd4cf
+    m_ActionName: UI/Click[/Mouse/leftButton,/Pen/tip]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 9c5e5910-82dc-41e3-8c44-36424117cdd6
+    m_ActionName: UI/ScrollWheel[/Mouse/scroll]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 97736e75-df5f-495c-8c0d-7fd2073219c9
+    m_ActionName: UI/MiddleClick[/Mouse/middleButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 4deb3bd1-05ec-4795-88c2-bfc6d7d5e461
+    m_ActionName: UI/RightClick[/Mouse/rightButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 1674919f-da8f-4f21-b877-317325f87af9
+    m_ActionName: UI/TrackedDevicePosition
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 5e49397b-868e-4a9a-b622-49b6248f5559
+    m_ActionName: UI/TrackedDeviceOrientation
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: Keyboard&Mouse
   m_DefaultActionMap: Player

--- a/Assets/_PlatformerDevelopment/Scripts/Player/PlayerJumpBehaviour.cs
+++ b/Assets/_PlatformerDevelopment/Scripts/Player/PlayerJumpBehaviour.cs
@@ -10,22 +10,25 @@ namespace PersonalDevelopment
         private const string FloorTag = "Floor";
         
         // Components
-        private PlayerCharacterBindings _bindings = null;
         private Rigidbody _rigidbody = null;
         
         // Fields
         [SerializeField] private float _jumpForce = 10f;
         private bool _canJump = true;
 
-        #region Movement
-
-        private void OnJumpPressed(InputAction.CallbackContext context)
+        #region PlayerInputInspector
+        /// <summary>
+        /// Used in PlayerInput Inspector
+        /// </summary>
+        /// <param name="context"></param>
+        public void OnJumpPressed(InputAction.CallbackContext context)
         {
-            if (_canJump)
+            if (_canJump && context.phase == InputActionPhase.Performed)
             {
                 _canJump = false;
                 _rigidbody.AddForce(Vector3.up * _jumpForce, ForceMode.Impulse);
             }
+            print("Jump: " + context.phase.ToString());
         }
 
         #endregion
@@ -34,21 +37,8 @@ namespace PersonalDevelopment
         private void Awake()
         {
             _rigidbody = GetComponent<Rigidbody>();
-            _bindings = new PlayerCharacterBindings();
         }
-
-        private void OnEnable()
-        {
-            _bindings.Player.Jump.performed += OnJumpPressed;
-            _bindings.Enable();
-        }
-
-        private void OnDisable()
-        {
-            _bindings.Player.Jump.performed -= OnJumpPressed;
-            _bindings.Disable();
-        }
-
+        
         private void OnCollisionEnter(Collision other)
         {
             if (other.gameObject.CompareTag(FloorTag))

--- a/Assets/_PlatformerDevelopment/Scripts/Player/PlayerJumpBehaviour.cs
+++ b/Assets/_PlatformerDevelopment/Scripts/Player/PlayerJumpBehaviour.cs
@@ -28,7 +28,6 @@ namespace PersonalDevelopment
                 _canJump = false;
                 _rigidbody.AddForce(Vector3.up * _jumpForce, ForceMode.Impulse);
             }
-            print("Jump: " + context.phase.ToString());
         }
 
         #endregion

--- a/Assets/_PlatformerDevelopment/Scripts/Player/PlayerMovementBehaviour.cs
+++ b/Assets/_PlatformerDevelopment/Scripts/Player/PlayerMovementBehaviour.cs
@@ -9,37 +9,41 @@ namespace PersonalDevelopment
     public class PlayerMovementBehaviour : MonoBehaviour
     {
         // Components
-        private PlayerCharacterBindings _bindings = null;
         private Rigidbody _rigidbody = null;
         
         // Movement 
         [SerializeField] private float _movementSpeed = 5f;
         private int _axisSingle = 0;
 
-        #region mono
+        #region PlayerInputInspector
+
+        /// <summary>
+        /// Used in inspector for player Input
+        /// </summary>
+        /// <param name="context"></param>
+        public void OnMove(InputAction.CallbackContext context)
+        {
+            switch (context.phase)
+            {
+                case InputActionPhase.Performed:
+                    OnMovePerformed(context);
+                    break;
+                case InputActionPhase.Canceled:
+                    OnMoveCancelled();
+                    break;
+            }
+        }
+
+        #endregion
         
+        #region mono
         // Start is called before the first frame update
         private void Awake()
         {
             // This will never be null, since this won't even compile without RigidBody on this gameobject
             _rigidbody = GetComponent<Rigidbody>();
-            _bindings = new PlayerCharacterBindings();
         }
         
-        private void OnEnable()
-        {
-            _bindings.Player.Move.performed += OnMovePressed;
-            _bindings.Player.Move.canceled += OnMoveCancelled;
-            _bindings.Enable();
-        }
-
-        private void OnDisable()
-        {
-            _bindings.Player.Move.performed -= OnMovePressed;
-            _bindings.Player.Move.canceled -= OnMoveCancelled;
-            _bindings.Disable();
-        }
-
         private void FixedUpdate()
         {
             Movement();
@@ -54,15 +58,13 @@ namespace PersonalDevelopment
             var movement = new Vector3(_axisSingle, 0 ,0) * _movementSpeed * Time.fixedDeltaTime;
             _rigidbody.MovePosition(transform.position + movement);
         }
-        #endregion
         
-        #region Delegate
-        private void OnMovePressed(InputAction.CallbackContext context)
+        private void OnMovePerformed(InputAction.CallbackContext context)
         {
             _axisSingle = (int) context.ReadValue<Single>();
         }
 
-        private void OnMoveCancelled(InputAction.CallbackContext context)
+        private void OnMoveCancelled()
         {
             _axisSingle = 0;
         }

--- a/Assets/_PlatformerDevelopment/Tests/CharacterControlTests.cs
+++ b/Assets/_PlatformerDevelopment/Tests/CharacterControlTests.cs
@@ -9,33 +9,43 @@ namespace Tests
 {
     public class CharacterControlTests : InputTestFixture
     {
-        private Keyboard keyboard = null;
-        
+        private Keyboard _keyboard = null;
+
         [SetUp]
         public override void Setup()
         {
             base.Setup();
             SceneManager.LoadScene("CharacterControl_Sandbox");
-            keyboard = InputSystem.AddDevice<Keyboard>();
+            _keyboard = InputSystem.AddDevice<Keyboard>();
         }
 
         [UnityTest]
-        public IEnumerator TestCharacterControlSandboxStart()
+        public IEnumerator Test_Sandbox_Start()
+        {
+            Assert.IsNotNull(GameObject.FindGameObjectWithTag("Player"));
+            yield return null;
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_Sandbox_PlayerInput_NotNull()
         {
             var player = GameObject.FindGameObjectWithTag("Player");
-            Assert.IsNotNull(player);
+            var input = player.GetComponent<PlayerInput>();
+            Assert.IsNotNull(input);
             yield return null;
         }
 
         [UnityTest]
-        public IEnumerator TestCharacterControlsPressingLeftArrowKeyGetsLowerXPosition()
+        public IEnumerator Test_PressLeftArrowKey_Lower_XPosition()
         {
             //Given
             var player = GameObject.FindGameObjectWithTag("Player");
+            var input = player.GetComponent<PlayerInput>();
+            input.SwitchCurrentControlScheme("Keyboard&Mouse", Keyboard.current);
             var before = player.gameObject.transform.position.x;
             
             //When
-            Press(keyboard.leftArrowKey);
+            Press(_keyboard.leftArrowKey);
             yield return new WaitForSeconds(0.5f);
             
             //Then
@@ -45,14 +55,16 @@ namespace Tests
         }
         
         [UnityTest]
-        public IEnumerator TestCharacterControlsPressingRightArrowKeyGetsHigherXPosition()
+        public IEnumerator Test_PressRightArrowKey_Higher_XPosition()
         {
             //Given 
             var player = GameObject.FindGameObjectWithTag("Player");
+            var input = player.GetComponent<PlayerInput>();
+            input.SwitchCurrentControlScheme("Keyboard&Mouse", Keyboard.current);
             var before = player.gameObject.transform.position.x;
             
             //When
-            Press(keyboard.rightArrowKey);
+            Press(_keyboard.rightArrowKey);
             yield return new WaitForSeconds(0.5f);
             
             //Then
@@ -62,14 +74,16 @@ namespace Tests
         }
         
         [UnityTest]
-        public IEnumerator TestCharacterControlsPressingDownArrowKeyGetsSameXPosition()
+        public IEnumerator Test_PressDownArrowKey_Equal_XPosition()
         {
             //Given 
             var player = GameObject.FindGameObjectWithTag("Player");
+            var input = player.GetComponent<PlayerInput>();
+            input.SwitchCurrentControlScheme("Keyboard&Mouse", Keyboard.current);
             var before = player.gameObject.transform.position.x;
             
             //When
-            Press(keyboard.upArrowKey);
+            Press(_keyboard.upArrowKey);
             yield return new WaitForSeconds(0.5f);
             
             //Then
@@ -79,14 +93,16 @@ namespace Tests
         }
         
         [UnityTest]
-        public IEnumerator TestCharacterControlsPressingUpArrowKeyGetsSameXPosition()
+        public IEnumerator Test_PressUpArrowKey_Equal_XPosition()
         {
             //Given 
             var player = GameObject.FindGameObjectWithTag("Player");
+            var input = player.GetComponent<PlayerInput>();
+            input.SwitchCurrentControlScheme("Keyboard&Mouse", Keyboard.current);
             var before = player.gameObject.transform.position.x;
             
             //When
-            Press(keyboard.downArrowKey);
+            Press(_keyboard.downArrowKey);
             yield return new WaitForSeconds(0.5f);
             
             //Then
@@ -96,14 +112,16 @@ namespace Tests
         }
         
         [UnityTest]
-        public IEnumerator TestCharacterControlsPressingUpArrowKeyDifferentYPosition()
+        public IEnumerator Test_PressUpArrowKey_Equal_YPosition()
         {
             //Given 
             var player = GameObject.FindGameObjectWithTag("Player");
+            var input = player.GetComponent<PlayerInput>();
+            input.SwitchCurrentControlScheme("Keyboard&Mouse", Keyboard.current);
             var before = player.gameObject.transform.position.x;
             
             //When
-            Press(keyboard.upArrowKey);
+            Press(_keyboard.upArrowKey);
             yield return new WaitForSeconds(0.5f);
             
             //Then
@@ -113,14 +131,16 @@ namespace Tests
         }
         
         [UnityTest]
-        public IEnumerator TestCharacterControlsPressingDownArrowKeySameYPosition()
+        public IEnumerator Test_PressDownArrowKey_Equal_YPosition()
         {
             //Given 
             var player = GameObject.FindGameObjectWithTag("Player");
+            var input = player.GetComponent<PlayerInput>();
+            input.SwitchCurrentControlScheme("Keyboard&Mouse", Keyboard.current);
             var before = player.gameObject.transform.position.y;
             
             //When
-            Press(keyboard.downArrowKey);
+            Press(_keyboard.downArrowKey);
             yield return new WaitForSeconds(0.5f);
             
             //Then
@@ -129,14 +149,34 @@ namespace Tests
         }
         
         [UnityTest]
-        public IEnumerator TestCharacterControlsPressingUpArrowKeyWaitFor2SecondsLandOnSamePosition()
+        public IEnumerator Test_PressUpArrowKey_Greater_YPosition()
         {
             //Given 
             var player = GameObject.FindGameObjectWithTag("Player");
+            var input = player.GetComponent<PlayerInput>();
+            input.SwitchCurrentControlScheme("Keyboard&Mouse", Keyboard.current);
+            var before = player.gameObject.transform.position.y;
+            
+            //When
+            Press(_keyboard.upArrowKey);
+            yield return new WaitForSeconds(0.5f);
+            
+            //Then
+            var after = player.gameObject.transform.position.y;
+            Assert.Greater(after, before, "Player should be in the same position since jump and land on same position");
+        }
+        
+        [UnityTest]
+        public IEnumerator Test_PressUpArrowKey_Wait2Seconds_Equal_Position()
+        {
+            //Given 
+            var player = GameObject.FindGameObjectWithTag("Player");
+            var input = player.GetComponent<PlayerInput>();
+            input.SwitchCurrentControlScheme("Keyboard&Mouse", Keyboard.current);
             var before = player.gameObject.transform.position;
             
             //When
-            Press(keyboard.upArrowKey);
+            Press(_keyboard.upArrowKey);
             yield return new WaitForSeconds(2f);
             
             //Then
@@ -146,21 +186,23 @@ namespace Tests
         
         
         [UnityTest]
-        public IEnumerator TestCharacterControlsPressUpAndRightToLandOnPlatform()
+        public IEnumerator Test_PressUpAndRight_On_Platform()
         {
             //Given 
             var player = GameObject.FindGameObjectWithTag("Player");
+            var input = player.GetComponent<PlayerInput>();
+            input.SwitchCurrentControlScheme("Keyboard&Mouse", Keyboard.current);
             var before = player.gameObject.transform.position;
             
             //When
-            PressAndRelease(keyboard.upArrowKey);
+            PressAndRelease(_keyboard.upArrowKey);
             yield return new WaitForSeconds(0.25f);
-            Press(keyboard.rightArrowKey);
+            Press(_keyboard.rightArrowKey);
             for (int i = 0; i < 100; i++)
             {
                 yield return new WaitForEndOfFrame();
             }
-            Release(keyboard.rightArrowKey);
+            Release(_keyboard.rightArrowKey);
             yield return new WaitForSeconds(1f);
             
             //Then


### PR DESCRIPTION
- I Fixed the player input bindings. 
Problem:
- I wasn't using PlayerInput Component at all. So I switched it so it was using it. 
- Also found out we need to use "Unity Event Callback" + drag drop methods in inspector. 
- The C# event callback sucks. given options are "Send Message", "BroadcastMessage", "Unity Event CallBack", "C# event callback" I chose the unity event call back since it seems the most cleanes. **SendMessage** only detects if you press something, not when you cancel, Broadcast is no way - "This broadcasts the message down the GameObject hierarchy."
https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/manual/Components.html - Under "Notifications" for details
- Led to changes in tests, needed to grab the Player gameObject and bind a device and control scheme to it.
